### PR TITLE
feat: enable read *.rens and *.rn file fixes #1

### DIFF
--- a/include/fileread.h
+++ b/include/fileread.h
@@ -1,0 +1,14 @@
+// `fileread.h` - header file for reading contents of rens file
+//
+// `fileread.c` scans if file is the accepted extension file (*.rens || *.rn).
+// It also allocates memory for a dynamic array where the contents of the
+// file is stored.
+
+// access the file contents with 'array_textdata'
+extern char *array_textdata;
+
+// detect file extension (*.rens || *.rn) and store values to 'array_textdata'
+extern int getRensFileContents(const char *filename);
+
+// free allocated array_textdata memory
+extern void freeTextdata();

--- a/src/fileread.c
+++ b/src/fileread.c
@@ -1,0 +1,54 @@
+// fileread header implementation
+//
+// `fileread.c` scans if file is the accepted extension file (*.rens || *.rn).
+// It also allocates memory for a dynamic array where the contents of the
+// file is stored.
+//
+// Several references:
+// https://stackoverflow.com/questions/54943083
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *array_textdata = NULL; // access file character array
+
+int getRensFileContents(const char *filename) {
+
+    // detect rens or rn file extension
+    if (!(strstr(filename, ".rens") || strstr(filename, ".rn"))) {
+        printf("[ERROR] FileNotSupported: unrecognized file extension '%s'\n",
+               filename);
+        return 1;
+    }
+
+    // open given filename input
+    FILE *file_ptr = fopen(filename, "r");
+    if (file_ptr == NULL) {
+        printf("[ERROR] FileNotFound: '%s'\n", filename);
+        return 1;
+    }
+
+    // determine length of characters in file
+    size_t size = 1;
+    while (getc(file_ptr) != EOF) {
+        size++;
+    }
+
+    // create memory with sizeof file contents character length
+    array_textdata = (char *)malloc(sizeof(char) * size);
+
+    fseek(file_ptr, 0, SEEK_SET); // Reset file pointer to begin
+    // assign each character to array_textdata array
+    for (size_t i = 0; i < size - 1; i++) {
+        array_textdata[i] = (char)getc(file_ptr);
+    }
+
+    array_textdata[size - 1] = '\0';
+
+    fclose(file_ptr);
+    return 0;
+}
+
+// free allocated array_textdata memory
+void freeTextdata() { free(array_textdata); }

--- a/src/main.c
+++ b/src/main.c
@@ -1,21 +1,27 @@
 #include "optflags.h"
+#include "fileread.h"
 #include <stdio.h>
 
-int main(const int argc, char *argv[]) {
-    // parse command line arguments
-    int status = parseOptionFlags(argc, argv);
-    if (status) {
-        return status;
+int main(const int argc, char **argv) {
+    // optflags.h - parse command line arguments
+    if (parseOptionFlags(argc, argv)) {
+        return 1;
     }
 
-    // confirm inputfile == .rens || .rn file extension
-    printf("%s\n", inputfile);
-    printf("%s\n", outputfile);
+    // fileread.h - validate extension and get contents in file
+    if (getRensFileContents(inputfile)) {
+        return 1;
+    }
+
     // read inputfile
+    printf("Input File: %s\n", inputfile);
+    printf("Output File: %s\n", outputfile);
+    printf("%s", array_textdata);
 
     // get tokens
 
     // pass to lexer
 
+    freeTextdata();
     return 0;
 }

--- a/test/file.rens
+++ b/test/file.rens
@@ -1,0 +1,5 @@
+Sample rens file
+\0
+\n
+\0
+sampe

--- a/test/test.md
+++ b/test/test.md
@@ -1,3 +1,0 @@
-# `test/` directory
-
-Store test related files.


### PR DESCRIPTION
# Added functionalities
- Detect if file passed is `*.rens` or `*.rn` fixes issue #1 
- Add accessible file contents with dynamic array in `fileread.h`
- Use `array_textdata` to access the file's contents