### PR TITLE
fix(main.c): fix illegal access to null inputfile

### DIFF
--- a/src/fileread.c
+++ b/src/fileread.c
@@ -39,7 +39,7 @@ int getRensFileContents(const char *filename) {
     array_textdata = (char *)malloc(sizeof(char) * size);
 
     fseek(file_ptr, 0, SEEK_SET); // Reset file pointer to begin
-    // assign each character to array_textdata array
+    // assign each character to each array_textdata index
     for (size_t i = 0; i < size - 1; i++) {
         array_textdata[i] = (char)getc(file_ptr);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
-#include "optflags.h"
-#include "fileread.h"
+#include "fileread.h" // char *array_textdata
+#include "optflags.h" // char *inputfile, *outputfile
 #include <stdio.h>
 
 int main(const int argc, char **argv) {
@@ -9,19 +9,25 @@ int main(const int argc, char **argv) {
     }
 
     // fileread.h - validate extension and get contents in file
-    if (getRensFileContents(inputfile)) {
-        return 1;
+    if (inputfile != NULL) {
+        if (getRensFileContents(inputfile)) {
+            return 1;
+        }
     }
 
-    // read inputfile
-    printf("Input File: %s\n", inputfile);
-    printf("Output File: %s\n", outputfile);
-    printf("%s", array_textdata);
+    // process inputfile's characters
+    if (array_textdata != NULL) {
+        // read inputfile
+        printf("Input File: %s\n", inputfile);
+        printf("Output File: %s\n", outputfile);
+        printf("%s", array_textdata);
+        // get tokens
 
-    // get tokens
+        // pass to lexer
+        
+        // free all memory
+        free(array_textdata);
+    }
 
-    // pass to lexer
-
-    freeTextdata();
     return 0;
 }


### PR DESCRIPTION
# Fix `SIGSEGV (Address boundary error)` on `-h` and `-v` arguments

## Reproduce Error on Previous Commit

1. Generate and build the program.
2. Execute the executable with `-h` or `-v` argument option:

    ```console
    ./build/renaisscript -h
    ```

    **Output**

    ```console
    Usage: renaisscript [option...] [rensfile...].rens

      -o <filename>     write output to file
      -h                print this help guide
      -v                print version information

    Only one option flag must be specified.
    fish: Job 1, './build/renaisscript -h' terminated by signal SIGSEGV (Address boundary error)
    ```

## Fixes

- Disable access to null `inputfile` when argument -v and -h are passed
- Disable access to null `array_textdata` when `inputfile` fails to open